### PR TITLE
Bump buildx to 0.16.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
       script: |
         mkdir -p $HOME/.docker/cli-plugins
         cd $HOME/.docker/cli-plugins
-        wget -q https://github.com/docker/buildx/releases/download/v0.12.0/buildx-v0.12.0.linux-$(dpkg --print-architecture) -O docker-buildx
+        wget -q https://github.com/docker/buildx/releases/download/v0.16.2/buildx-v0.16.2.linux-$(dpkg --print-architecture) -O docker-buildx
         chmod +x ~/.docker/cli-plugins/docker-buildx
   
   - task: CmdLine@2


### PR DESCRIPTION
https://github.com/docker/buildx/releases/tag/v0.16.2